### PR TITLE
Install django-rgd-imagery

### DIFF
--- a/dev/celery.Dockerfile
+++ b/dev/celery.Dockerfile
@@ -1,12 +1,15 @@
 FROM python:3.8-slim
 # Install system librarires for Python packages:
 # * psycopg2
+# * python-magic
 RUN apt-get update && \
     apt-get install --no-install-recommends --yes \
         libpq-dev \
         gcc \
         libc6-dev \
         libmagic1 \
+        fuse \
+        docker.io \
         && \
     rm -rf /var/lib/apt/lists/*
 
@@ -18,8 +21,11 @@ ENV PYTHONUNBUFFERED 1
 # over top of this directory, the .egg-link in site-packages resolves to the mounted directory
 # and all package modules are importable.
 COPY ./setup.py /opt/django-project/setup.py
+COPY ./fuse.sh /opt/django-project/fuse.sh
 # Use a directory name which will never be an import name, as isort considers this as first-party.
 WORKDIR /opt/django-project
 RUN pip install \
     --find-links https://girder.github.io/large_image_wheels \
-    -e .[dev]
+    -e .[dev,worker,fuse]
+
+ENTRYPOINT ["/opt/django-project/fuse.sh"]

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -20,7 +20,7 @@ services:
   celery:
     build:
       context: .
-      dockerfile: ./dev/django.Dockerfile
+      dockerfile: ./dev/celery.Dockerfile
     command: [
       "celery",
       "--app", "ts_demo.celery",
@@ -30,6 +30,7 @@ services:
     ]
     # Docker Compose does not set the TTY width, which causes Celery errors
     tty: false
+    privileged: true
     env_file: ./dev/.env.docker-compose
     volumes:
       - .:/opt/django-project
@@ -37,3 +38,9 @@ services:
       - postgres
       - rabbitmq
       - minio
+
+  flower:
+    image: mher/flower
+    command: ["--broker=amqp://rabbitmq:5672/", "--url_prefix=flower"]
+    ports:
+      - 5555:5555

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,14 @@
 version: '3'
 services:
   postgres:
-    image: postgres:latest
+    image: postgis/postgis:latest
     environment:
       POSTGRES_DB: django
       POSTGRES_PASSWORD: postgres
     ports:
       - ${DOCKER_POSTGRES_PORT-5432}:5432
+    volumes:
+      - dbdata:/var/lib/postgresql/data
 
   rabbitmq:
     image: rabbitmq:management
@@ -23,3 +25,9 @@ services:
       MINIO_SECRET_KEY: minioSecretKey
     ports:
       - ${DOCKER_MINIO_PORT-9000}:9000
+    volumes:
+      - fsdata:/data
+
+volumes:
+  dbdata:
+  fsdata:

--- a/fuse.sh
+++ b/fuse.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+mkdir -p /tmp/rgd/https
+python -m simple_httpfs /tmp/rgd/https
+mkdir -p /tmp/rgd/http
+python -m simple_httpfs /tmp/rgd/http
+exec "$@"

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,8 @@ setup(
         'django-composed-configuration[prod]',
         'django-s3-file-field[boto3]',
         'gunicorn',
+        'django-rgd',
+        'django-rgd-imagery',
     ],
     extras_require={
         'dev': [
@@ -57,6 +59,12 @@ setup(
             'django-s3-file-field[minio]',
             'ipython',
             'tox',
-        ]
+        ],
+        'worker': [
+            'django-rgd-imagery[worker]',
+        ],
+        'fuse': [
+            'django-rgd[fuse]>=0.2.2',
+        ],
     },
 )

--- a/ts_demo/settings.py
+++ b/ts_demo/settings.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
+from typing import Type
 
 from composed_configuration import (
     ComposedConfiguration,
@@ -10,13 +12,47 @@ from composed_configuration import (
     ProductionBaseConfiguration,
     TestingBaseConfiguration,
 )
+from configurations import values
 
 
-class TsDemoMixin(ConfigMixin):
+class GeoDjangoMixin(ConfigMixin):
+    @staticmethod
+    def before_binding(configuration: Type[ComposedConfiguration]):
+        configuration.INSTALLED_APPS += ['django.contrib.gis']
+        try:
+            import re
+
+            import osgeo
+
+            libsdir = os.path.join(
+                os.path.dirname(os.path.dirname(osgeo._gdal.__file__)), 'GDAL.libs'
+            )
+            libs = {
+                re.split(r'-|\.', name)[0]: os.path.join(libsdir, name)
+                for name in os.listdir(libsdir)
+            }
+            configuration.GDAL_LIBRARY_PATH = libs['libgdal']
+            configuration.GEOS_LIBRARY_PATH = libs['libgeos_c']
+        except Exception:
+            # TODO: Log that we aren't using the expected GDAL wheel?
+            pass
+
+
+class SwaggerMixin(ConfigMixin):
+    REFETCH_SCHEMA_WITH_AUTH = True
+    REFETCH_SCHEMA_ON_LOGOUT = True
+    OPERATIONS_SORTER = 'alpha'
+    DEEP_LINKING = True
+
+
+class TsDemoMixin(GeoDjangoMixin, SwaggerMixin, ConfigMixin):
     WSGI_APPLICATION = 'ts_demo.wsgi.application'
     ROOT_URLCONF = 'ts_demo.urls'
 
     BASE_DIR = Path(__file__).resolve(strict=True).parent.parent
+
+    RGD_GLOBAL_READ_ACCESS = values.Value(default=False)
+    RGD_FILE_FIELD_PREFIX = values.Value(default=None)
 
     @staticmethod
     def before_binding(configuration: ComposedConfiguration) -> None:
@@ -28,7 +64,24 @@ class TsDemoMixin(ConfigMixin):
         # Install additional apps
         configuration.INSTALLED_APPS += [
             's3_file_field',
+            'rgd',
+            'rgd_imagery',
         ]
+
+        configuration.REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'].append(
+            'rest_framework.authentication.BasicAuthentication'
+        )
+
+    # This cannot have a default value, since the password and database name are always
+    # set by the service admin
+    DATABASES = values.DatabaseURLValue(
+        environ_name='DATABASE_URL',
+        environ_prefix='DJANGO',
+        environ_required=True,
+        # Additional kwargs to DatabaseURLValue are passed to dj-database-url
+        engine='django.contrib.gis.db.backends.postgis',
+        conn_max_age=600,
+    )
 
 
 class DevelopmentConfiguration(TsDemoMixin, DevelopmentBaseConfiguration):
@@ -36,7 +89,8 @@ class DevelopmentConfiguration(TsDemoMixin, DevelopmentBaseConfiguration):
 
 
 class TestingConfiguration(TsDemoMixin, TestingBaseConfiguration):
-    pass
+    CELERY_TASK_ALWAYS_EAGER = True
+    CELERY_TASK_EAGER_PROPAGATES = True
 
 
 class ProductionConfiguration(TsDemoMixin, ProductionBaseConfiguration):
@@ -44,4 +98,11 @@ class ProductionConfiguration(TsDemoMixin, ProductionBaseConfiguration):
 
 
 class HerokuProductionConfiguration(TsDemoMixin, HerokuProductionBaseConfiguration):
-    pass
+    DATABASES = values.DatabaseURLValue(
+        environ_name='DATABASE_URL',
+        environ_prefix=None,
+        environ_required=True,
+        engine='django.contrib.gis.db.backends.postgis',
+        conn_max_age=600,
+        ssl_require=True,
+    )

--- a/ts_demo/urls.py
+++ b/ts_demo/urls.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.contrib import admin
-from django.urls import include, path
+from django.urls import include, path, re_path
+from django.views.generic.base import RedirectView
 from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
 from rest_framework import permissions, routers
@@ -21,6 +22,34 @@ urlpatterns = [
     path('api/v1/', include(router.urls)),
     path('api/docs/redoc/', schema_view.with_ui('redoc'), name='docs-redoc'),
     path('api/docs/swagger/', schema_view.with_ui('swagger'), name='docs-swagger'),
+    path('', include('rgd.urls')),
+    path('', include('rgd_imagery.urls')),
+    # Redirect homepage to RGD core app homepage
+    path(r'', RedirectView.as_view(url='rgd', permanent=False), name='index'),
+]
+
+schema_view = get_schema_view(
+    openapi.Info(
+        title='ResonantGeoData Tile Server Demo API',
+        default_version='v1',
+        description='ResonantGeoData Tile Server Demo',
+        # terms_of_service='https://www.google.com/policies/terms/',
+        contact=openapi.Contact(email='rgd@kitare.com'),
+        license=openapi.License(name='Apache 2.0'),
+    ),
+    public=False,
+    permission_classes=(permissions.AllowAny,),
+    patterns=urlpatterns,
+)
+
+urlpatterns += [
+    re_path(
+        r'^swagger(?P<format>\.json|\.yaml)$',
+        schema_view.without_ui(cache_timeout=0),
+        name='schema-json',
+    ),
+    path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
Demonstration of how to install `django-rgd-imagery` into a Girder 4 project from the cookiecutter